### PR TITLE
feat: migrate from multipaz 0.92.0 to 0.93.0 TrustManager API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
-# IntelliJ IDEA
+# IntelliJ IDEA / Android Studio
 .idea/
+**/.idea/
 *.iws
 *.iml
 *.ipr
@@ -271,3 +272,9 @@ node_modules/
 # Temporary folders
 tmp/
 temp/ 
+
+# Kotlin build cache
+Holder/.kotlin/ 
+
+# IntelliJ IDEA / Android Studio
+.idea/ 

--- a/Holder/gradle/libs.versions.toml
+++ b/Holder/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinx-coroutines = "1.8.1"
 kotlinx-io = "0.4.0"
 kotlinx-datetime = "0.6.0"
 kotlinx-serialization = "1.7.3"
-multipaz = "0.92.1"
+multipaz = "0.93.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
BREAKING CHANGE: Update TrustManager to use new 0.93.0+ syntax
- Replace TrustManager().apply { addTrustPoint(...) } with TrustManagerLocal API
- Fix deprecated printStack() to printStackTrace()
- Update .gitignore for IDE and build cache directories
- Addresses: https://github.com/openmobilehub/developer-multipaz-website/issues/23

This commit migrates the codelab from multipaz 0.92.0 to 0.93.0+, updating the reader trust management implementation to use the new API.

NOTE: Additional changes still pending in documentation and code-starter branch.