### PR TITLE
feat: migrate TrustManager to multipaz 0.93.0+ API

### DIFF
--- a/Holder/gradle/libs.versions.toml
+++ b/Holder/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinx-coroutines = "1.8.1"
 kotlinx-io = "0.4.0"
 kotlinx-datetime = "0.6.0"
 kotlinx-serialization = "1.7.3"
-multipaz = "0.92.1"
+multipaz = "0.93.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
- Replace TrustManager().apply { addTrustPoint(...) } with TrustManagerLocal API
- Fix deprecated printStack() to printStackTrace()
- Update gradle dependencies in libs.versions.toml
- Addresses: https://github.com/openmobilehub/developer-multipaz-website/issues/23

This commit migrates the codelab from multipaz 0.92.0 to 0.93.0+, updating the reader trust management implementation to use the new API.