### PR TITLE
Fix intent misrouting by switching to custom URI scheme

### DIFF
--- a/Holder/composeApp/src/androidMain/AndroidManifest.xml
+++ b/Holder/composeApp/src/androidMain/AndroidManifest.xml
@@ -52,40 +52,38 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-
             <!-- Deep Link Configuration -->
 
-            <!-- 1. HTTPS App Links (default) - Requires .well-known/assetlinks.json -->
-            <!-- Examples: https://apps.multipaz.org/landing/ -->
+            <!-- Option #1 - Custom URI Scheme (default) - App-specific URLs -->
+            <!-- Examples: wholesale-test-app://landing -->
             <!-- Must match ApplicationSupportLocal.APP_LINK_SERVER -->
-            <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <!--
-                Do not include other schemes, only https. If domain is changed here, it
-                also MUST be changed in ApplicationSupportLocal class.
-                 -->
-                <data
-                    android:scheme="https"
-                    android:host="apps.multipaz.org"
-                    android:pathPattern="/landing/.*"/>
-            </intent-filter>
-
-            <!-- 2. Custom URI Scheme - App-specific URLs -->
-            <!-- Examples: multipaz-test-app://landing -->
-            <!-- Must match ApplicationSupportLocal.APP_LINK_SERVER -->
-            <!-- This is an alternative to HTTPS App Links (above) which require .well-known/assetlinks.json -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="multipaz-test-app"/>
+                <data android:scheme="wholesale-test-app"/>
                 <data android:host="landing"/>
             </intent-filter>
 
-            <!-- 3. OpenID4VCI Credential Offers -->
+            <!-- Option #2 - HTTPS App Links - Requires .well-known/assetlinks.json -->
+            <!-- Examples: https://apps.multipaz.org/landing/ -->
+            <!-- Must match ApplicationSupportLocal.APP_LINK_SERVER -->
+            <!--<intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                &lt;!&ndash;
+                Do not include other schemes, only https. If domain is changed here, it
+                also MUST be changed in ApplicationSupportLocal class.
+                 &ndash;&gt;
+                <data
+                    android:scheme="https"
+                    android:host="apps.multipaz.org"
+                    android:pathPattern="/landing/.*"/>
+            </intent-filter>-->
+
+            <!-- OpenID4VCI Credential Offers -->
             <!-- Examples: openid-credential-offer://, haip:// -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -98,6 +96,7 @@
                 <!-- Accept all hosts for any of the defined schemes above -->
                 <data android:host="*"/>
             </intent-filter>
+
         </activity>
 
         <activity

--- a/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ProvisioningSupport.kt
+++ b/Holder/composeApp/src/commonMain/kotlin/org/multipaz/samples/wallet/cmp/ProvisioningSupport.kt
@@ -45,12 +45,13 @@ import kotlin.time.ExperimentalTime
 class ProvisioningSupport: OpenID4VCIBackend {
     val TAG ="PRO:ProvisioningSupport"
     companion object Companion {
-        const val APP_LINK_SERVER = "https://apps.multipaz.org"
-        const val APP_LINK_BASE_URL = "$APP_LINK_SERVER/landing/"
+        const val APP_LINK_SERVER = "wholesale-test-app"
+        const val APP_LINK_BASE_URL = "${APP_LINK_SERVER}://landing/"
 
-// Alternative custom scheme (security is lower)
-//        const val APP_LINK_SERVER = "multipaz-test-app"
-//        const val APP_LINK_BASE_URL = "${APP_LINK_SERVER}://landing/"
+        // Alternative HTTP App Links (more secure). See AndroidManifest.xml Option #2
+        /*const val APP_LINK_SERVER = "https://apps.multipaz.org"
+        const val APP_LINK_BASE_URL = "$APP_LINK_SERVER/landing/"*/
+
 
         private val localClientAssertionJwk = Json.parseToJsonElement("""
             {


### PR DESCRIPTION
Fixes: https://github.com/openwallet-foundation/multipaz-samples/issues/2

Changes:
- Remove HTTPS app links configuration that was causing conflicts with Test App
- Switch from multipaz-test-app:// to wholesale-test-app:// custom URI scheme
- Update ProvisioningSupport to use wholesale-test-app://landing/ as base URL
- Remove autoVerify requirement that was causing intent misrouting

This resolves the issue where intents were being misrouted to the Test App instead of the intended Utopia App when both apps are installed. The custom URI scheme approach provides more reliable intent handling without conflicts.